### PR TITLE
Safer and simpler versions

### DIFF
--- a/System/Mem/StableName/Dynamic/Map.hs
+++ b/System/Mem/StableName/Dynamic/Map.hs
@@ -2,6 +2,9 @@
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Unsafe #-}
 #endif
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE StandaloneDeriving #-}
 module System.Mem.StableName.Dynamic.Map
     ( Map
     , empty
@@ -12,27 +15,47 @@ module System.Mem.StableName.Dynamic.Map
     , insert
     , insertWith
     , insertWith'
+    , adjust
+    , adjust'
+    , fromList
     , lookup
     , find
     , findWithDefault
     ) where
 
-import qualified Prelude
 import Prelude hiding (lookup, null)
 import System.Mem.StableName.Dynamic
-import qualified Data.IntMap as IntMap
-import Data.IntMap (IntMap)
+import qualified Data.HashMap.Lazy as M
+import qualified Data.HashMap.Strict as MS
+import Data.HashMap.Lazy (HashMap)
+import qualified Data.Foldable as F
+import qualified Data.Traversable as T
+import Data.Hashable (Hashable)
+#if MIN_VERSION_base(4,9,0)
+import Data.Functor.Classes (Eq1, Show1 (..))
+#endif
 
-newtype Map a = Map { getMap :: IntMap [(DynamicStableName, a)] } 
+newtype Map a = Map { getMap :: HashMap DynamicStableName a }
+  deriving (Eq, Hashable, Functor, F.Foldable, T.Traversable)
+
+instance Show a => Show (Map a) where
+  showsPrec d (Map m) = showsPrec d m
+
+#if MIN_VERSION_base(4,9,0)
+deriving instance Eq1 Map
+
+instance Show1 Map where
+  liftShowsPrec se sl p (Map m) = liftShowsPrec se sl p m
+#endif
 
 empty :: Map a
-empty = Map IntMap.empty
+empty = Map M.empty
 
 null :: Map a -> Bool
-null (Map m) = IntMap.null m
+null (Map m) = M.null m
 
 singleton :: DynamicStableName -> a -> Map a
-singleton k v = Map $ IntMap.singleton (hashDynamicStableName k) [(k,v)]
+singleton k v = Map $ M.singleton k v
 
 member :: DynamicStableName -> Map a -> Bool
 member k m = case lookup k m of
@@ -43,7 +66,10 @@ notMember :: DynamicStableName -> Map a -> Bool
 notMember k m = not $ member k m 
 
 insert :: DynamicStableName -> a -> Map a -> Map a
-insert k v = Map . IntMap.insertWith (++) (hashDynamicStableName k) [(k,v)] . getMap
+insert k v = Map . M.insert k v . getMap
+
+fromList :: [(DynamicStableName, a)] -> Map a
+fromList = Map . M.fromList
     
 -- | /O(log n)/. Insert with a function for combining the new value and old value.
 -- @'insertWith' f key value mp@
@@ -51,30 +77,24 @@ insert k v = Map . IntMap.insertWith (++) (hashDynamicStableName k) [(k,v)] . ge
 -- in the map. If the key does exist, the function will insert the pair
 -- @(key, f new_value old_value)@
 insertWith :: (a -> a -> a) -> DynamicStableName -> a -> Map a -> Map a
-insertWith f k v = Map . IntMap.insertWith go (hashDynamicStableName k) [(k,v)] . getMap 
-    where 
-        go _ ((k',v'):kvs) 
-            | k == k' = (k', f v v') : kvs
-            | otherwise = (k',v') : go undefined kvs
-        go _ [] = []
+insertWith f k v = Map . M.insertWith f k v . getMap 
 
 -- | Same as 'insertWith', but with the combining function applied strictly.
 insertWith' :: (a -> a -> a) -> DynamicStableName -> a -> Map a -> Map a
-insertWith' f k v = Map . IntMap.insertWith go (hashDynamicStableName k) [(k,v)] . getMap 
-    where 
-        go _ ((k',v'):kvs) 
-            | k == k' = let v'' = f v v' in v'' `seq` (k', v'') : kvs
-            | otherwise = (k', v') : go undefined kvs
-        go _ [] = []
+insertWith' f k v = Map . MS.insertWith f k v . getMap 
+
+adjust :: (a -> a) -> DynamicStableName -> Map a -> Map a
+adjust f k = Map . M.adjust f k . getMap
+
+adjust' :: (a -> a) -> DynamicStableName -> Map a -> Map a
+adjust' f k = Map . MS.adjust f k . getMap
 
 -- | /O(log n)/. Lookup the value at a key in the map.
 -- 
 -- The function will return the corresponding value as a @('Just' value)@
 -- or 'Nothing' if the key isn't in the map.
 lookup :: DynamicStableName -> Map v -> Maybe v
-lookup k (Map m) = do
-    pairs <- IntMap.lookup (hashDynamicStableName k) m
-    Prelude.lookup k pairs
+lookup k (Map m) = M.lookup k m
 
 find :: DynamicStableName -> Map v -> v
 find k m = case lookup k m of

--- a/System/Mem/StableName/Map.hs
+++ b/System/Mem/StableName/Map.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 702
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE Trustworthy #-}
+#elif __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Unsafe #-}
-#endif
-#if __GLASGOW_HASKELL__ >= 707
-{-# LANGUAGE RoleAnnotations #-}
 #endif
 module System.Mem.StableName.Map
     ( Map
+    , Representational
     , empty
     , null
     , singleton
@@ -16,111 +16,11 @@ module System.Mem.StableName.Map
     , insertWith
     , insertWith'
     , adjust
+    , adjust'
     , lookup
     , find
     , findWithDefault
     ) where
 
-import GHC.Prim (Any)
-import qualified Prelude
-import Prelude hiding (lookup, null, any)
-import System.Mem.StableName
-import System.Mem.StableName.Dynamic
-import qualified Data.IntMap as IntMap
-import Data.IntMap (IntMap)
-import Unsafe.Coerce (unsafeCoerce)
-
--- | Note: this can be generally unsound when `f` is a GADT!
-newtype Map f = Map { getMap :: IntMap [(DynamicStableName, f Any)] }
-#if __GLASGOW_HASKELL__ >= 707
-type role Map nominal
-#endif
-
--- unsafe combinators
-any :: f a -> f Any
-any = unsafeCoerce
-
-liftAny1 :: (f a -> f a) -> f Any -> f Any
-liftAny1 f a = unsafeCoerce $ f (unsafeCoerce a)
-
-empty :: Map f
-empty = Map IntMap.empty
-
-null :: Map f -> Bool
-null (Map m) = IntMap.null m
-
-singleton :: StableName a -> f a -> Map f
-singleton k v = Map $ IntMap.singleton (hashDynamicStableName dk) [(dk, any v)]
-    where
-        dk = wrapStableName k
-
-member :: StableName a -> Map f -> Bool
-member k m = case lookup k m of
-    Nothing -> False
-    Just _ -> True
-
-notMember :: StableName a -> Map f -> Bool
-notMember k m = not $ member k m
-
-insert :: StableName a -> f a -> Map f -> Map f
-insert k v =
-    Map .
-    IntMap.insertWith (++) (hashDynamicStableName dk) [(dk,any v)] .
-    getMap
-    where
-        dk = wrapStableName k
-
--- | /O(log n)/. Insert with a function for combining the new value and old value.
--- @'insertWith' f key value mp@
--- will insert the pair (key, value) into @mp@ if the key does not exist
--- in the map. If the key does exist, the function will insert the pair
--- @(key, f new_value old_value)@
-insertWith :: (f a -> f a -> f a) -> StableName a -> f a -> Map f -> Map f
-insertWith f k v = Map . IntMap.insertWith go (hashDynamicStableName dk) [(dk,any v)] . getMap
-    where
-        dk = wrapStableName k
-        go _ ((k',v'):kvs)
-            | dk == k' = (k', liftAny1 (f v) v') : kvs
-            | otherwise = (k',v') : go undefined kvs
-        go _ [] = [(dk, any v)]
-
--- | Same as 'insertWith', but with the combining function applied strictly.
-insertWith' :: (f a -> f a -> f a) -> StableName a -> f a -> Map f -> Map f
-insertWith' f k v = Map . IntMap.insertWith go (hashDynamicStableName dk) [(dk, any v)] . getMap
-    where
-        dk = wrapStableName k
-        go _ ((k',v'):kvs)
-            | dk == k' = let v'' = liftAny1 (f v) v' in v'' `seq` (k', v'') : kvs
-            | otherwise = (k', v') : go undefined kvs
-        go _ [] = [(dk, any v)]
-
-adjust :: (f a -> f a) -> StableName a -> Map f -> Map f
-adjust f k = Map . IntMap.adjust go (hashDynamicStableName dk) . getMap
-    where
-        dk = wrapStableName k
-        go ((k',v):kvs)
-            | dk == k' = (k', liftAny1 f v) : kvs
-            | otherwise = (k', v) : go kvs
-        go [] = []
-
--- | /O(log n)/. Lookup the value at a key in the map.
---
--- The function will return the corresponding value as a @('Just' value)@
--- or 'Nothing' if the key isn't in the map.
-lookup :: StableName a -> Map f -> Maybe (f a)
-lookup k (Map m) = do
-    pairs <- IntMap.lookup (hashDynamicStableName dk) m
-    unsafeCoerce $ Prelude.lookup dk pairs
-    where
-        dk = wrapStableName k
-
-find :: StableName a -> Map f -> f a
-find k m = case lookup k m of
-    Nothing -> error "Map.find: element not in the map"
-    Just x -> x
-
--- | /O(log n)/. The expression @('findWithDefault' def k map)@ returns
--- the value at key @k@ or returns the default value @def@
--- when the key is not in the map.
-findWithDefault :: f a -> StableName a -> Map f -> f a
-findWithDefault dflt k m = maybe dflt id $ lookup k m
+import System.Mem.StableName.Map.Internal
+import Prelude hiding (null, lookup)

--- a/System/Mem/StableName/Map/Internal.hs
+++ b/System/Mem/StableName/Map/Internal.hs
@@ -1,0 +1,150 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Unsafe #-}
+#endif
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE RoleAnnotations #-}
+#endif
+{-# LANGUAGE TypeFamilies #-}
+#if __GLASGOW_HASKELL__ >= 806
+{-# LANGUAGE QuantifiedConstraints, MonoLocalBinds #-}
+#endif
+{-# LANGUAGE FlexibleInstances, FlexibleContexts, UndecidableInstances #-}
+{-# LANGUAGE EmptyDataDecls #-}
+
+module System.Mem.StableName.Map.Internal
+    ( Map (..)
+    , Representational
+#if (__GLASGOW_HASKELL__ >= 708) && (__GLASGOW_HASKELL__ < 806)
+    -- This prevents a stupid warning, but we don't actually
+    -- expose it outside the package.
+    , Skolem2 (..)
+#endif
+    , empty
+    , unsafeEmpty
+    , null
+    , singleton
+    , unsafeSingleton
+    , member
+    , notMember
+    , insert
+    , insertWith
+    , insertWith'
+    , adjust
+    , adjust'
+    , lookup
+    , find
+    , findWithDefault
+    ) where
+
+import GHC.Exts (Any)
+import Prelude hiding (lookup, null, any)
+import System.Mem.StableName
+import System.Mem.StableName.Dynamic
+import qualified Data.HashMap.Lazy as M
+import qualified Data.HashMap.Strict as MS
+import Data.HashMap.Lazy (HashMap)
+import Unsafe.Coerce (unsafeCoerce)
+#if __GLASGOW_HASKELL__ >= 708
+import Data.Coerce
+#endif
+
+newtype Map f = Map { getMap :: HashMap DynamicStableName (f Any) }
+#if __GLASGOW_HASKELL__ >= 708
+type role Map nominal
+#endif
+
+#if __GLASGOW_HASKELL__ >= 806
+class (forall a b. Coercible a b => Coercible (f a) (f b))
+  => Representational f
+instance (forall a b. Coercible a b => Coercible (f a) (f b))
+  => Representational f
+#elif __GLASGOW_HASKELL__ >= 708
+-- Is this safe? Could be....
+data Skolem1
+newtype Skolem2 = Skolem2 Skolem1
+
+class Representational (f :: * -> *)
+instance Coercible (f Skolem1) (f Skolem2) => Representational f
+#else
+-- Definitely not safe.
+class Represesentational (f :: * -> *)
+instance Representational f
+#endif
+
+-- unsafe combinators
+any :: f a -> f Any
+any = unsafeCoerce
+
+liftAny1 :: (f a -> f a) -> f Any -> f Any
+liftAny1 f a = unsafeCoerce f a
+
+liftAny2 :: (f a -> f a -> f a) -> f Any -> f Any -> f Any
+liftAny2 f a b = unsafeCoerce f a b
+
+empty :: Representational f => Map f
+empty = unsafeEmpty
+
+unsafeEmpty :: Map f
+unsafeEmpty = Map M.empty
+
+null :: Map f -> Bool
+null (Map m) = M.null m
+
+singleton :: Representational f => StableName a -> f a -> Map f
+singleton = unsafeSingleton
+
+unsafeSingleton :: StableName a -> f a -> Map f
+unsafeSingleton k v = Map $ M.singleton (wrapStableName k) (any v)
+
+member :: StableName a -> Map f -> Bool
+member k m = case lookup k m of
+    Nothing -> False
+    Just _ -> True
+
+notMember :: StableName a -> Map f -> Bool
+notMember k m = not $ member k m
+
+insert :: StableName a -> f a -> Map f -> Map f
+insert k v =
+    Map .
+    M.insert (wrapStableName k) (any v) .
+    getMap
+
+-- | /O(log n)/. Insert with a function for combining the new value and old value.
+-- @'insertWith' f key value mp@
+-- will insert the pair (key, value) into @mp@ if the key does not exist
+-- in the map. If the key does exist, the function will insert the pair
+-- @(key, f new_value old_value)@
+insertWith :: (f a -> f a -> f a) -> StableName a -> f a -> Map f -> Map f
+insertWith f k v =
+  Map . M.insertWith (liftAny2 f) (wrapStableName k) (any v) . getMap
+
+-- | Same as 'insertWith', but with the combining function applied strictly.
+insertWith' :: (f a -> f a -> f a) -> StableName a -> f a -> Map f -> Map f
+insertWith' f k v =
+  Map . MS.insertWith (liftAny2 f) (wrapStableName k) (any v) . getMap
+
+adjust :: (f a -> f a) -> StableName a -> Map f -> Map f
+adjust f k = Map . M.adjust (liftAny1 f) (wrapStableName k) . getMap
+
+adjust' :: (f a -> f a) -> StableName a -> Map f -> Map f
+adjust' f k = Map . MS.adjust (liftAny1 f) (wrapStableName k) . getMap
+
+-- | /O(log n)/. Lookup the value at a key in the map.
+--
+-- The function will return the corresponding value as a @('Just' value)@
+-- or 'Nothing' if the key isn't in the map.
+lookup :: StableName a -> Map f -> Maybe (f a)
+lookup k (Map m) = unsafeCoerce (M.lookup (wrapStableName k) m)
+
+find :: StableName a -> Map f -> f a
+find k m = case lookup k m of
+    Nothing -> error "Map.find: element not in the map"
+    Just x -> x
+
+-- | /O(log n)/. The expression @('findWithDefault' def k map)@ returns
+-- the value at key @k@ or returns the default value @def@
+-- when the key is not in the map.
+findWithDefault :: f a -> StableName a -> Map f -> f a
+findWithDefault dflt k m = maybe dflt id $ lookup k m

--- a/System/Mem/StableName/Map/Unsafe.hs
+++ b/System/Mem/StableName/Map/Unsafe.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE Unsafe #-}
+
+-- | The API in "System.Mem.StableName.Map" allows @'Map' f@ only
+-- when @f@'s parameter has a representational role. This module
+-- exports functions that defeat that restriction. If it breaks,
+-- you get to keep both pieces. In many cases,
+-- "System.Mem.StableName.TypedMap" will do the trick, but it's
+-- somewhat less efficient.
+module System.Mem.StableName.Map.Unsafe
+    ( unsafeEmpty
+    , unsafeSingleton
+    ) where
+
+import System.Mem.StableName.Map.Internal

--- a/System/Mem/StableName/TypedMap.hs
+++ b/System/Mem/StableName/TypedMap.hs
@@ -1,0 +1,129 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif
+#if __GLASGOW_HASKELL__ >= 707
+{-# LANGUAGE RoleAnnotations #-}
+#endif
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+-- | @"System.Mem.StableName.Map".'System.Mem.StableName.Map.Map' f@
+-- is only permitted (without unsafe functions) when @f@'s parameter
+-- has a representational role. This module relaxes that restriction
+-- by using 'Typeable' to distinguish between values with the same
+-- representation but different types.
+module System.Mem.StableName.TypedMap
+    ( Map
+    , empty
+    , null
+    , singleton
+    , member
+    , notMember
+    , insert
+    , insertWith
+    , insertWith'
+    , adjust
+    , adjust'
+    , lookup
+    , find
+    , findWithDefault
+    ) where
+
+import GHC.Exts (Any)
+import Prelude hiding (lookup, null, any)
+import System.Mem.StableName
+import System.Mem.StableName.TaggedSN
+import qualified Data.HashMap.Lazy as M
+import qualified Data.HashMap.Strict as MS
+import Data.HashMap.Lazy (HashMap)
+import Unsafe.Coerce (unsafeCoerce)
+import Data.Typeable (Typeable)
+import Data.Hashable (Hashable)
+
+newtype Map f = Map { getMap :: HashMap TaggedSN (f Any) }
+#if __GLASGOW_HASKELL__ >= 707
+type role Map nominal
+#endif
+
+-- These instances are extremely restrictive, but they're the
+-- best we can do!
+instance Show (f Any) => Show (Map f) where
+  showsPrec d (Map m) = showParen (d > 10) $
+    showString "Map " . showsPrec 0 (M.toList m)
+
+deriving instance Hashable (f Any) => Hashable (Map f)
+
+deriving instance Eq (f Any) => Eq (Map f)
+
+-- unsafe combinators
+any :: f a -> f Any
+any = unsafeCoerce
+
+liftAny1 :: (f a -> f a) -> f Any -> f Any
+liftAny1 f a = unsafeCoerce $ f (unsafeCoerce a)
+
+liftAny2 :: (f a -> f a -> f a) -> f Any -> f Any -> f Any
+liftAny2 f a = unsafeCoerce f a
+
+empty :: Map f
+empty = Map M.empty
+
+null :: Map f -> Bool
+null (Map m) = M.null m
+
+singleton :: Typeable a => StableName a -> f a -> Map f
+singleton k v = Map $ M.singleton (wrapTaggedSN k) (any v)
+
+member :: Typeable a => StableName a -> Map f -> Bool
+member k m = case lookup k m of
+    Nothing -> False
+    Just _ -> True
+
+notMember :: Typeable a => StableName a -> Map f -> Bool
+notMember k m = not $ member k m
+
+insert :: Typeable a => StableName a -> f a -> Map f -> Map f
+insert k v =
+    Map .
+    M.insert (wrapTaggedSN k) (any v) .
+    getMap
+
+-- | /O(log n)/. Insert with a function for combining the new value and old value.
+-- @'insertWith' f key value mp@
+-- will insert the pair (key, value) into @mp@ if the key does not exist
+-- in the map. If the key does exist, the function will insert the pair
+-- @(key, f new_value old_value)@
+insertWith :: Typeable a => (f a -> f a -> f a) -> StableName a -> f a -> Map f -> Map f
+insertWith f k v = Map . M.insertWith (liftAny2 f) (wrapTaggedSN k) (any v) . getMap
+
+-- | Same as 'insertWith', but with the combining function applied strictly.
+insertWith' :: Typeable a => (f a -> f a -> f a) -> StableName a -> f a -> Map f -> Map f
+insertWith' f k v = Map . MS.insertWith (liftAny2 f) (wrapTaggedSN k) (any v) . getMap
+
+adjust :: Typeable a => (f a -> f a) -> StableName a -> Map f -> Map f
+adjust f k = Map . M.adjust (liftAny1 f) (wrapTaggedSN k) . getMap
+
+adjust' :: Typeable a => (f a -> f a) -> StableName a -> Map f -> Map f
+adjust' f k = Map . MS.adjust (liftAny1 f) (wrapTaggedSN k) . getMap
+
+-- | /O(log n)/. Lookup the value at a key in the map.
+--
+-- The function will return the corresponding value as a @('Just' value)@
+-- or 'Nothing' if the key isn't in the map.
+lookup :: Typeable a => StableName a -> Map f -> Maybe (f a)
+lookup k (Map m) = do
+  val <- M.lookup (wrapTaggedSN k) m
+  return (unsafeCoerce val)
+
+find :: Typeable a => StableName a -> Map f -> f a
+find k m = case lookup k m of
+    Nothing -> error "Map.find: element not in the map"
+    Just x -> x
+
+-- | /O(log n)/. The expression @('findWithDefault' def k map)@ returns
+-- the value at key @k@ or returns the default value @def@
+-- when the key is not in the map.
+findWithDefault :: Typeable a => f a -> StableName a -> Map f -> f a
+findWithDefault dflt k m = maybe dflt id $ lookup k m

--- a/stable-maps.cabal
+++ b/stable-maps.cabal
@@ -19,9 +19,15 @@ source-repository head
 
 Library
   Exposed-modules: System.Mem.StableName.Map
+                   System.Mem.StableName.Map.Unsafe
                    System.Mem.StableName.Dynamic
+                   System.Mem.StableName.TypedMap
                    System.Mem.StableName.Dynamic.Map
+                   System.Mem.StableName.TaggedSN
+  Other-modules:   System.Mem.StableName.Map.Internal
   Build-depends:   base       >= 4   && < 5,
-                   containers >= 0.3 && < 0.6,
-                   ghc-prim   >= 0.2 && < 0.4
+                   containers >= 0.3 && < 0.8,
+                   -- ghc-prim   >= 0.2 && < 0.6,
+                   hashable   >= 1.1.2,
+                   unordered-containers
   GHC-Options:     -Wall


### PR DESCRIPTION
* Make `StableName.Map` work for GADTs.

* Use `HashMap` everywhere instead of `IntMap` (for simplicity).

* Make `insertWith'` as strict as advertised.

* Add missing `adjust` variants.

Closes #6