### PR TITLE
Add traversals

### DIFF
--- a/System/Mem/StableName/Map.hs
+++ b/System/Mem/StableName/Map.hs
@@ -17,6 +17,11 @@ module System.Mem.StableName.Map
     , insertWith'
     , adjust
     , adjust'
+    , hmap
+    , hfoldMap
+    , htraverse
+    , hmap'
+    , htraverse'
     , lookup
     , find
     , findWithDefault

--- a/System/Mem/StableName/Map/Internal.hs
+++ b/System/Mem/StableName/Map/Internal.hs
@@ -6,35 +6,46 @@
 {-# LANGUAGE RoleAnnotations #-}
 #endif
 {-# LANGUAGE TypeFamilies #-}
-#if __GLASGOW_HASKELL__ >= 806
+#if __GLASGOW_HASKELL__ >= 805
 {-# LANGUAGE QuantifiedConstraints, MonoLocalBinds #-}
 #endif
 {-# LANGUAGE FlexibleInstances, FlexibleContexts, UndecidableInstances #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE RankNTypes #-}
 
 module System.Mem.StableName.Map.Internal
     ( Map (..)
     , Representational
-#if (__GLASGOW_HASKELL__ >= 708) && (__GLASGOW_HASKELL__ < 806)
+#if (__GLASGOW_HASKELL__ >= 708) && (__GLASGOW_HASKELL__ < 805)
     -- This prevents a stupid warning, but we don't actually
     -- expose it outside the package.
     , Skolem2 (..)
 #endif
     , empty
-    , unsafeEmpty
     , null
     , singleton
-    , unsafeSingleton
     , member
     , notMember
     , insert
     , insertWith
     , insertWith'
+    , unsafeInsertWith
+    , unsafeInsertWith'
     , adjust
     , adjust'
+    , unsafeAdjust
+    , unsafeAdjust'
+    , hmap
+    , hfoldMap
+    , htraverse
+    , hmap'
+    , htraverse'
     , lookup
+    , unsafeLookup
     , find
+    , unsafeFind
     , findWithDefault
+    , unsafeFindWithDefault
     ) where
 
 import GHC.Exts (Any)
@@ -48,13 +59,15 @@ import Unsafe.Coerce (unsafeCoerce)
 #if __GLASGOW_HASKELL__ >= 708
 import Data.Coerce
 #endif
+import qualified Data.Foldable as F
+import qualified Data.Traversable as T
 
 newtype Map f = Map { getMap :: HashMap DynamicStableName (f Any) }
 #if __GLASGOW_HASKELL__ >= 708
 type role Map nominal
 #endif
 
-#if __GLASGOW_HASKELL__ >= 806
+#if __GLASGOW_HASKELL__ >= 805
 class (forall a b. Coercible a b => Coercible (f a) (f b))
   => Representational f
 instance (forall a b. Coercible a b => Coercible (f a) (f b))
@@ -82,23 +95,17 @@ liftAny1 f a = unsafeCoerce f a
 liftAny2 :: (f a -> f a -> f a) -> f Any -> f Any -> f Any
 liftAny2 f a b = unsafeCoerce f a b
 
-empty :: Representational f => Map f
-empty = unsafeEmpty
-
-unsafeEmpty :: Map f
-unsafeEmpty = Map M.empty
+empty :: Map f
+empty = Map M.empty
 
 null :: Map f -> Bool
 null (Map m) = M.null m
 
-singleton :: Representational f => StableName a -> f a -> Map f
-singleton = unsafeSingleton
-
-unsafeSingleton :: StableName a -> f a -> Map f
-unsafeSingleton k v = Map $ M.singleton (wrapStableName k) (any v)
+singleton :: StableName a -> f a -> Map f
+singleton k v = Map $ M.singleton (wrapStableName k) (any v)
 
 member :: StableName a -> Map f -> Bool
-member k m = case lookup k m of
+member k m = case unsafeLookup k m of
     Nothing -> False
     Just _ -> True
 
@@ -116,35 +123,95 @@ insert k v =
 -- will insert the pair (key, value) into @mp@ if the key does not exist
 -- in the map. If the key does exist, the function will insert the pair
 -- @(key, f new_value old_value)@
-insertWith :: (f a -> f a -> f a) -> StableName a -> f a -> Map f -> Map f
-insertWith f k v =
+insertWith
+  :: Representational f
+  => (f a -> f a -> f a) -> StableName a -> f a -> Map f -> Map f
+insertWith = unsafeInsertWith
+
+unsafeInsertWith
+  :: (f a -> f a -> f a) -> StableName a -> f a -> Map f -> Map f
+unsafeInsertWith f k v =
   Map . M.insertWith (liftAny2 f) (wrapStableName k) (any v) . getMap
 
 -- | Same as 'insertWith', but with the combining function applied strictly.
-insertWith' :: (f a -> f a -> f a) -> StableName a -> f a -> Map f -> Map f
-insertWith' f k v =
+insertWith'
+  :: Representational f
+  => (f a -> f a -> f a) -> StableName a -> f a -> Map f -> Map f
+insertWith' = unsafeInsertWith'
+
+unsafeInsertWith' :: (f a -> f a -> f a) -> StableName a -> f a -> Map f -> Map f
+unsafeInsertWith' f k v =
   Map . MS.insertWith (liftAny2 f) (wrapStableName k) (any v) . getMap
 
-adjust :: (f a -> f a) -> StableName a -> Map f -> Map f
-adjust f k = Map . M.adjust (liftAny1 f) (wrapStableName k) . getMap
+adjust
+  :: Representational f
+  => (f a -> f a) -> StableName a -> Map f -> Map f
+adjust = unsafeAdjust
 
-adjust' :: (f a -> f a) -> StableName a -> Map f -> Map f
-adjust' f k = Map . MS.adjust (liftAny1 f) (wrapStableName k) . getMap
+unsafeAdjust :: (f a -> f a) -> StableName a -> Map f -> Map f
+unsafeAdjust f k = Map . M.adjust (liftAny1 f) (wrapStableName k) . getMap
+
+adjust'
+  :: Representational f
+  => (f a -> f a) -> StableName a -> Map f -> Map f
+adjust' = unsafeAdjust'
+
+unsafeAdjust' :: (f a -> f a) -> StableName a -> Map f -> Map f
+unsafeAdjust' f k = Map . MS.adjust (liftAny1 f) (wrapStableName k) . getMap
+
+hmap
+  :: (forall a. f a -> g a)
+  -> Map f -> Map g
+hmap f (Map m) = Map (fmap f m)
+
+hmap'
+  :: (forall a. f a -> g a)
+  -> Map f -> Map g
+hmap' f (Map m) = Map (MS.map f m)
+
+hfoldMap
+  :: Monoid m
+  => (forall a. f a -> m)
+  -> Map f -> m
+hfoldMap f (Map m) = F.foldMap f m
+
+htraverse
+  :: Applicative m
+  => (forall a. f a -> m (g a))
+  -> Map f -> m (Map g)
+htraverse f (Map m) = Map <$> T.traverse f m
+
+htraverse'
+  :: Applicative m
+  => (forall a. f a -> m (g a))
+  -> Map f -> m (Map g)
+htraverse' f (Map m) = Map <$> MS.traverseWithKey (\_ v -> f v) m
 
 -- | /O(log n)/. Lookup the value at a key in the map.
 --
 -- The function will return the corresponding value as a @('Just' value)@
 -- or 'Nothing' if the key isn't in the map.
-lookup :: StableName a -> Map f -> Maybe (f a)
-lookup k (Map m) = unsafeCoerce (M.lookup (wrapStableName k) m)
+lookup
+  :: Representational f
+  => StableName a -> Map f -> Maybe (f a)
+lookup = unsafeLookup
 
-find :: StableName a -> Map f -> f a
-find k m = case lookup k m of
+unsafeLookup :: StableName a -> Map f -> Maybe (f a)
+unsafeLookup k (Map m) = unsafeCoerce (M.lookup (wrapStableName k) m)
+
+find :: Representational f => StableName a -> Map f -> f a
+find = unsafeFind
+
+unsafeFind :: StableName a -> Map f -> f a
+unsafeFind k m = case unsafeLookup k m of
     Nothing -> error "Map.find: element not in the map"
     Just x -> x
 
 -- | /O(log n)/. The expression @('findWithDefault' def k map)@ returns
 -- the value at key @k@ or returns the default value @def@
 -- when the key is not in the map.
-findWithDefault :: f a -> StableName a -> Map f -> f a
-findWithDefault dflt k m = maybe dflt id $ lookup k m
+findWithDefault :: Representational f => f a -> StableName a -> Map f -> f a
+findWithDefault = unsafeFindWithDefault
+
+unsafeFindWithDefault :: f a -> StableName a -> Map f -> f a
+unsafeFindWithDefault dflt k m = maybe dflt id $ unsafeLookup k m

--- a/System/Mem/StableName/Map/Unsafe.hs
+++ b/System/Mem/StableName/Map/Unsafe.hs
@@ -7,8 +7,13 @@
 -- "System.Mem.StableName.TypedMap" will do the trick, but it's
 -- somewhat less efficient.
 module System.Mem.StableName.Map.Unsafe
-    ( unsafeEmpty
-    , unsafeSingleton
+    ( unsafeInsertWith
+    , unsafeInsertWith'
+    , unsafeAdjust
+    , unsafeAdjust'
+    , unsafeLookup
+    , unsafeFind
+    , unsafeFindWithDefault
     ) where
 
 import System.Mem.StableName.Map.Internal

--- a/stable-maps.cabal
+++ b/stable-maps.cabal
@@ -27,7 +27,6 @@ Library
   Other-modules:   System.Mem.StableName.Map.Internal
   Build-depends:   base       >= 4   && < 5,
                    containers >= 0.3 && < 0.8,
-                   -- ghc-prim   >= 0.2 && < 0.6,
                    hashable   >= 1.1.2,
                    unordered-containers
   GHC-Options:     -Wall


### PR DESCRIPTION
* Add `hmap`, `hfoldMap`, and `htraverse` for `StableName.Map`.

* Rejigger `Representational` constraints so `hmap` and `htraverse`
  aren't unreasonably constrained.

Closes #8

This also goes a long way toward resolving #1. The only remaining
discrepancy I see is `fromList`. One option might be to follow
`dependent-map`.